### PR TITLE
Make it easier to install YottaDB from a source or binary tarball

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -894,9 +894,11 @@ install(FILES sr_unix/lowerc_cp.sh DESTINATION ${YDB_INSTALL_DIR}
   RENAME lowerc_cp
   )
 
-if (EXISTS ${YDB_SOURCE_DIR}/COPYING)
-  install(FILES COPYING DESTINATION ${YDB_INSTALL_DIR})
-endif()
+foreach(d COPYING README.md)
+  if (EXISTS ${YDB_SOURCE_DIR}/${d})
+    install(FILES ${d} DESTINATION ${YDB_INSTALL_DIR})
+  endif()
+endforeach()
 
 add_custom_target(place_files ALL DEPENDS ${files_to_place})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,10 @@
 cmake_minimum_required(VERSION 2.8.5)
 project(YDB C ASM)
 
+# By default, cmake uses -rdynamic for C link-time flags. That is not needed here and bloats executable sizes unnecessarily.
+# So disable that by defining the link-time C flags to the null string.
+set(CMAKE_SHARED_LIBRARY_LINK_C_FLAGS  )
+
 # Max optimization level is -O2
 get_property(languages GLOBAL PROPERTY ENABLED_LANGUAGES)
 foreach(lang ${languages})

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ versions of packages from the distribution repositories.
 
    ```sh
    $ tar xfz yottadb_r110_src.tar.gz
-   $ cd yottadb_r110
+   $ cd yottadb_r110_src
    ```
 
    You should find this README, LICENSE, COPYING and CMakeLists.txt file and sr_* source directories.
@@ -47,27 +47,21 @@ versions of packages from the distribution repositories.
    >
 
    ```sh
-   $ cmake ../
-   $ make
+   $ cmake -D CMAKE_INSTALL_PREFIX:PATH=$PWD ../
+   $ make -j `grep -c processor /proc/cpuinfo`
    $ make install
-   $ cd yottadb/r110
+   $ cd yottadb_r110
    ```
 
   Note that the make install done above does not create the final installed YottaDB.
   Instead, it stages YottaDB for distribution.
 
-  Now you are ready to install YottaDB. Answer a few questions and install it.
-  The recommended installation path is `/opt/yottadb/r110`
+  Now you are ready to install YottaDB. The default installation path is ```/usr/local/lib/yottadb/r110```
+  but can be controlled using the --installdir option. Run ```./ydbinstall --help``` for a list of options.
 
   ```sh
-  $ sudo ./ydbinstall	# to install the version you just built
+  $ sudo ./ydbinstall
   $ cd - ; make clean
-  ```
-
-  (Note: The below will help get installation options if needed.)
-
-  ```sh
-  # ./ydbinstall --help	# get installation options
   ```
 
 4. Packaging YottaDB

--- a/README.md
+++ b/README.md
@@ -17,7 +17,14 @@ versions of packages from the distribution repositories.
    Install developement libraries
 
    ```sh
-    cmake tcsh {libconfig,libelf,libgcrypt,libgpg-error,libgpgme11,libicu,libncurses,libssl,zlib1g}-dev
+    Ubuntu Linux OR Raspbian Linux OR Beagleboard Debian
+	sudo aptitude install cmake tcsh {libconfig,libelf,libgcrypt,libgpg-error,libgpgme11,libicu,libncurses,libssl,zlib1g}-dev
+
+    Arch Linux
+	sudo pacman -S cmake tcsh {libconfig,libelf,libgcrypt,libgpg-error,gpgme,icu,ncurses,openssl,zlib}
+
+    CentOS Linux OR RedHat Linux
+	sudo yum install git gcc cmake tcsh {libconfig,gpgme,libicu,libgpg-error,libgcrypt,ncurses,openssl,zlib,elfutils-libelf}-devel
    ```
 
    There may be other library dependencies or the packages may have different names.

--- a/sr_unix/configure.gtc
+++ b/sr_unix/configure.gtc
@@ -131,11 +131,11 @@ if [ "" != "$issystemd" ] ; then
 		echo "   $ipcline2"
 		echo "And issue the below command to restart systemd-logind"
 		echo "   $ipccmd"
-		if [ -z ${ydb_configure_removeipc} ] ; then
+		if [ -z ${ydb_change_removeipc} ] ; then
 			echo -n "Do you wish to proceed (Y/N)? "
 			answer=`read_yes_no`
 		else
-			answer=${ydb_configure_removeipc}
+			answer=${ydb_change_removeipc}
 		fi
 		if [ "yes" != "$answer" ] ; then
 			echo "Will abort installation"

--- a/sr_unix/configure.gtc
+++ b/sr_unix/configure.gtc
@@ -376,23 +376,16 @@ if [ "$doutf8" -ne 0 ]; then
 	fi
 fi
 
-# Install COPYING if it is applicable
-file=COPYING
-if [ -f $file ]; then
-	cp -p $file $gtmdist
-	if [ "$doutf8" -ne 0 ]; then
-		ln -s ../$file $gtmdist/utf8/$file
+# Install COPYING as well as README.md (YottaDB) or README.txt (GT.M) if it is applicable
+for file in COPYING README.md README.txt
+do
+	if [ -f $file ]; then
+		cp -p $file $gtmdist
+		if [ "$doutf8" -ne 0 ]; then
+			ln -s ../$file $gtmdist/utf8/$file
+		fi
 	fi
-fi
-
-# Install README.txt if it is applicable
-file=README.txt
-if [ -f $file ]; then
-	cp -p $file $gtmdist
-	if [ "$doutf8" -ne 0 ]; then
-		ln -s ../$file $gtmdist/utf8/$file
-	fi
-fi
+done
 
 # Install custom_errors_sample.txt if it is applicable
 file=custom_errors_sample.txt
@@ -805,7 +798,7 @@ read resp
 if [ "$resp" = "Y" -o "$resp" = "y" ] ; then
 	\rm -rf $binaries $pathmods $rscripts $nscripts $dirs configure \
 		*.gtc gtm* gde* GDE*.o _*.m _*.o mumps.dat mumps.gld geteuid $other_object_files $csh_script_files lowerc_cp\
-		*.hlp core *.h *.m *help.dat *help.gld COPYING README.txt
+		*.hlp core *.h *.m *help.dat *help.gld COPYING README.md README.txt
 	\rm -rf GETPASS.o plugin GTMHELP.o custom_errors_sample.txt
 	if [ -d utf8 ]; then
 		\rm -rf utf8

--- a/sr_unix/configure.gtc
+++ b/sr_unix/configure.gtc
@@ -107,6 +107,53 @@ $echo "Copyright (c) 2017 YottaDB LLC. and/or its subsidiaries."
 $echo "All rights reserved."
 $echo ""
 
+issystemd=`which systemctl`
+if [ "" != "$issystemd" ] ; then
+	# It is a systemd installation
+	# Check if RemoveIPC=no is set. If not, prompt user for okay to set this. If user says NO, abort the install.
+	logindconf="/etc/systemd/logind.conf"
+	removeipcopt=`awk -F = '/^RemoveIPC/ {opt=$2} END{print opt}' $logindconf`
+	if [ "no" != "$removeipcopt" ] ; then
+		# RemoveIPC=no is NOT the final settings in the file
+		ipcissue1="If RemoveIPC=yes is configured for systemd, ipcs (database shm & sem)"
+		ipcissue1="$ipcissue1 are removed for a non-system user's processes when that user logs out."
+		ipcissue2="That can cause database operations to fail with mysterious errors."
+
+		ipcline1="# YottaDB : Override systemd default of RemoveIPC=yes to prevent automatic ipc removal of"
+		ipcline1="$ipcline1 Shared Memory Segments and Semaphore Arrays of orphaned databases"
+		ipcline2="RemoveIPC=no"
+		ipccmd="systemctl restart systemd-logind"
+
+		echo "$ipcissue1"
+		echo "$ipcissue2"
+		echo "The installation would like to add the below two lines to $logindconf"
+		echo "   $ipcline1"
+		echo "   $ipcline2"
+		echo "And issue the below command to restart systemd-logind"
+		echo "   $ipccmd"
+		if [ -z ${ydb_configure_removeipc} ] ; then
+			echo -n "Do you wish to proceed (Y/N)? "
+			answer=`read_yes_no`
+		else
+			answer=${ydb_configure_removeipc}
+		fi
+		if [ "yes" != "$answer" ] ; then
+			echo "Will abort installation"
+			echo $ipcissue1
+			echo $ipcissue2
+			echo "Please add the below two lines to $logindconf"
+			echo "   $ipcline1"
+			echo "   $ipcline2"
+			echo "and restart systemd-logind using the below command, for example or by rebooting the system"
+			echo "   $ipccmd"
+			echo "and retry YottaDB installation"
+			exit 1
+		fi
+		echo $ipcline1 >> $logindconf
+		echo $ipcline2 >> $logindconf
+		$ipccmd
+	fi
+fi
 # Native super user and group
 rootuser=root
 bingroup=bin
@@ -116,6 +163,7 @@ defowner=bin
 touch tmp_owngrp
 $echo "What user account should own the files? ($defowner) \c"
 read resp
+if [ ! -t 0 ] ; then echo "$resp"; fi
 if [ "$resp" = "" ] ; then
 	owner=$defowner
 else
@@ -131,6 +179,7 @@ fi
 
 $echo "What group should own the files? ($bingroup) \c"
 read resp
+if [ ! -t 0 ] ; then echo "$resp"; fi
 if [ "$resp" != "" ] ; then
 	bingroup=$resp
 fi
@@ -144,6 +193,7 @@ fi
 
 $echo "Should execution of YottaDB be restricted to this group? (y or n) \c"
 read resp
+if [ ! -t 0 ] ; then echo "$resp"; fi
 if [ "$resp" = "Y" -o "$resp" = "y" ] ; then
 	# root and bin are invalid groups to be restricted
 	if [ 0 = $bingroup -o "bin" = $bingroup -o "root" = $bingroup ] ; then
@@ -162,6 +212,7 @@ rm tmp_owngrp
 
 $echo "In what directory should YottaDB be installed? \c"
 read gtmdist
+if [ ! -t 0 ] ; then echo "$gtmdist"; fi
 
 # if gtmdist is relative then need to make it absolute
 
@@ -183,6 +234,7 @@ else
 	$echo "this installation? (y or n) \c"
 fi
 read resp
+if [ ! -t 0 ] ; then echo "$resp"; fi
 if [ "$resp" = "Y" -o "$resp" = "y" ] ; then
 	mkdir -p        $gtmdist/plugin/r $gtmdist/plugin/o
 	chmod 0755      $gtmdist/plugin/r $gtmdist/plugin/o $gtmdist
@@ -220,13 +272,16 @@ if [ -d "utf8" ]; then
 	fi
 	$echo "Should UTF-8 support be installed? (y or n) \c"
 	read resp
+	if [ ! -t 0 ] ; then echo "$resp"; fi
 	if [ "$resp" = "Y" -o "$resp" = "y" ] ; then
 		would_like_utf8=1
 		$echo "Should an ICU version other than the default be used? (y or n) \c"
 		read resp
+		if [ ! -t 0 ] ; then echo "$resp"; fi
 		if [ "$resp" = "Y" -o "$resp" = "y" ] ; then
 			$echo "Enter ICU version (at least ICU version 3.6 is required. Enter as <major-ver>.<minor-ver>): \c"
 			read gtm_icu_version
+			if [ ! -t 0 ] ; then echo "$gtm_icu_version"; fi
 			maj=`$echo $gtm_icu_version | cut -f 1 -d "."`
 			if [ "$maj" -ge "49" ] ; then
 				# Assuming the input is of the form 52.1. As of ICU 49 (aka 4.9),
@@ -575,8 +630,9 @@ $echo "You can create lowercase copies of these routines if you wish, but"
 $echo "to avoid problems with compatibility in the future, consider keeping"
 $echo "only the uppercase versions of the files."
 $echo ""
-$echo "Do you want uppercase and lowercase versions of the MUMPS routines? (y or n)\c"
+$echo "Do you want uppercase and lowercase versions of the MUMPS routines? (y or n) \c"
 read resp
+if [ ! -t 0 ] ; then echo "$resp"; fi
 if [ "$resp" = "Y" -o "$resp" = "y" ] ; then
 	$echo ""
 	$echo "Creating lowercase versions of the MUMPS routines."
@@ -693,6 +749,7 @@ if [ -f $gtm_dist/libgtmutil$ext ] ; then
 	$echo "Object files of M routines placed in shared library $gtm_dist/libgtmutil$ext"
 	$echo "Keep original .o object files (y or n)? \c"
 	read resp
+	if [ ! -t 0 ] ; then echo "$resp"; fi
 	if [ "n" = "$resp" -o "N" = "$resp" ] ; then rm -f $gtm_dist/*.o $gtm_dist/utf8/*.o ; fi
 	$echo ""
 	if [ -f $gtm_dist/utf8/libgtmutil$ext ] ; then
@@ -794,6 +851,7 @@ $echo ""
 $echo "Installation completed. Would you like all the temporary files"
 $echo "removed from this directory? (y or n) \c"
 read resp
+if [ ! -t 0 ] ; then echo "$resp"; fi
 
 if [ "$resp" = "Y" -o "$resp" = "y" ] ; then
 	\rm -rf $binaries $pathmods $rscripts $nscripts $dirs configure \

--- a/sr_unix/ydbinstall.sh
+++ b/sr_unix/ydbinstall.sh
@@ -336,7 +336,7 @@ if [ -z "$ydb_version" ] ; then
         chmod +x $gtm_dist/mumps
         tmp=`mktmpdir`
         gtmroutines="$tmp($gtm_dist)" ; export gtmroutines
-        ydb_version=`$gtm_dist/mumps -run %XCMD '$piece($zyrelease," ",2)'`
+        ydb_version=`$gtm_dist/mumps -run %XCMD 'write $piece($zyrelease," ",2)'`
         rm -rf $tmp
     fi
 fi

--- a/sr_unix/ydbinstall.sh
+++ b/sr_unix/ydbinstall.sh
@@ -107,7 +107,7 @@ help_exit()
     echo "--copyexec dirname - copy gtm script to dirname; incompatible with linkexec"
     echo "--debug - * turn on debugging with set -x"
     echo "--distrib dirname or URL - source directory for YottaDB/GT.M distribution tarball, local or remote"
-    echo "--donotchangeRemoveIPC - do not allow changes to RemoveIPC in /etc/systemd/login.conf if needed; defaults to allow changes"
+    echo "--preserveRemoveIPC - do not allow changes to RemoveIPC in /etc/systemd/login.conf if needed; defaults to allow changes"
     echo "--dry-run - do everything short of installing YottaDB, including downloading the distribution"
     echo "--group group - group that should own the YottaDB installation"
     echo "--group-restriction - limit execution to a group; defaults to unlimited if not specified"
@@ -212,7 +212,6 @@ while [ $# -gt 0 ] ; do
                 fi
             fi
             shift ;;
-        --donotchangeRemoveIPC) ydb_change_removeipc="no" ; shift ;; # must come before group*
         --dry-run) gtm_dryrun="Y" ; shift ;;
         --gtm)
             gtm_gtm="Y"
@@ -251,6 +250,7 @@ while [ $# -gt 0 ] ; do
             unset gtm_copyexec
             shift ;;
         --overwrite-existing) gtm_overwrite_existing="Y" ; shift ;;
+        --preserveRemoveIPC) ydb_change_removeipc="no" ; shift ;; # must come before group*
         --prompt-for-group) gtm_prompt_for_group="Y" ; shift ;;
         --ucaseonly-utils) gtm_lcase_utils="N" ; shift ;;
         --user*) tmp=`echo $1 | cut -s -d = -f 2-`


### PR DESCRIPTION
README.md : Make it easier to build and install YottaDB from source

ydbinstall.sh
  a) Fix more occurrences of GT.M/gtm to YottaDB/ydb
  b) Make help more useful by printing some example usages
  c) Do not print full help in case of an error. Just point to help so actual error is highlighted.
  d) Add support for Linux on ARMV7L
  e) Fix bug (default case label should be "*" and not "default")
  f) Derive YottaDB release # (not GT.M version #) if ydbinstall and mumps are bundled together
  g) Issue error messages if wget fails
  h) Starting YottaDB r1.10, there will be binary tarballs for Linux x86_64, RHEL x86_64
     and Linux armv7l (named yottadb_r110_linux_x8664_pro.tgz, yottadb_r110_rhel7_x8664_pro.tgz
     and yottadb_r110_linux_armv7l_pro.tgz respectively). Enhance this script to determine the
     appropriate tarball for the current host and download it.